### PR TITLE
Fix bug: After logout and creating new account side menu is opened

### DIFF
--- a/lib/providers/app_provider.dart
+++ b/lib/providers/app_provider.dart
@@ -10,6 +10,7 @@ import 'package:memri/widgets/loading_indicator.dart';
 
 import '../core/services/database/schema.dart';
 import '../cvu/controllers/cvu_controller.dart';
+import 'ui_state_provider.dart';
 
 enum AppState { init, loading, success, error, unauthenticated, authenticating }
 
@@ -109,5 +110,6 @@ class AppProvider with ChangeNotifier {
   resetApp() async {
     await GetIt.I<SettingsProvider>().clear();
     await Authentication.instance.removeAll();
+    GetIt.I<UIStateProvider>().closeDrawer();
   }
 }

--- a/lib/providers/ui_state_provider.dart
+++ b/lib/providers/ui_state_provider.dart
@@ -21,6 +21,13 @@ class UIStateProvider with ChangeNotifier {
     notifyListeners();
   }
 
+  void closeDrawer() {
+    if (_isDrawerOpen) {
+      _isDrawerOpen = false;
+      notifyListeners();
+    }
+  }
+
   bool get isDrawerOpen => _isDrawerOpen;
 
   bool get filterPanelIsVisible => _filterPanelIsVisible;
@@ -47,6 +54,7 @@ class UIStateProvider with ChangeNotifier {
       Navigator.push(context, route);
     }
 
+    closeDrawer();
     navigateToContext(viewContextController);
   }
 


### PR DESCRIPTION
Add a method to close the side menu after logout or account creation.

* **UIStateProvider**: Add `closeDrawer` method to explicitly close the side menu. Call `closeDrawer` in the `navigateToScreen` method to ensure the side menu is closed when navigating to a new screen.
* **AppProvider**: Call `UIStateProvider`'s `closeDrawer` method in the `resetApp` method to close the side menu after logout.

